### PR TITLE
DAGs didn't work in alpha because of kube2iam restrictions

### DIFF
--- a/pq_flattener.py
+++ b/pq_flattener.py
@@ -7,7 +7,7 @@ from airflow.utils.dates import days_ago
 
 
 FLATTENER_IMAGE = "quay.io/mojanalytics/pq_flattener:v1.0.0"
-FLATTENER_IAM_ROLE = "alpha_pq_flattener"
+FLATTENER_IAM_ROLE = "airflow_pq_flattener"
 
 FLATTENER_GLUE_JOB_BUCKET = "alpha-cds-curated-open-data"
 FLATTENER_SOURCE_PATH = f"s3://alpha-cds-raw/open_data/parliamentary_questions/"

--- a/pq_scraper.py
+++ b/pq_scraper.py
@@ -7,7 +7,7 @@ from airflow.utils.dates import days_ago
 
 
 SCRAPER_IMAGE = "quay.io/mojanalytics/pq_scraper:v0.1.2"
-SCRAPER_IAM_ROLE = "alpha_pq_scraper_dag"
+SCRAPER_IAM_ROLE = "airflow_pq_scraper"
 SCRAPER_S3_BUCKET = "alpha-cds-raw"
 SCRAPER_S3_OBJECT_PREFIX = "open_data/parliamentary_questions/answered_questions_"
 


### PR DESCRIPTION
kube2iam can only assume IAM roles starting with `airflow_`