### PR TITLE
PQ DAGs: Disable emails on retry

### DIFF
--- a/pq_flattener.py
+++ b/pq_flattener.py
@@ -21,7 +21,7 @@ START_DATE = datetime(2018, 8, 15)
 task_args = {
     "depends_on_past": False,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 20,
     "retry_delay": timedelta(seconds=30),
     "retry_exponential_backoff": True,

--- a/pq_scraper.py
+++ b/pq_scraper.py
@@ -18,7 +18,7 @@ REUPDATE_LAST_N_DAYS = 31
 task_args = {
     "depends_on_past": False,
     "email_on_failure": True,
-    "email_on_retry": True,
+    "email_on_retry": False,
     "retries": 20,
     "retry_delay": timedelta(seconds=30),
     "retry_exponential_backoff": True,


### PR DESCRIPTION
Things can fail, retries are in place to handle failures.
Notifications of retries are a bit noisy so probably more
useful to get only failure notification emails.