### PR TITLE
pq_scraper: Updated image to fix security problem

### DIFF
--- a/pq_scraper.py
+++ b/pq_scraper.py
@@ -6,7 +6,7 @@ from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOpera
 from airflow.utils.dates import days_ago
 
 
-SCRAPER_IMAGE = "quay.io/mojanalytics/pq_scraper:v0.1.2"
+SCRAPER_IMAGE = "quay.io/mojanalytics/pq_scraper:v0.1.3"
 SCRAPER_IAM_ROLE = "airflow_pq_scraper"
 SCRAPER_S3_BUCKET = "mojap-raw"
 SCRAPER_S3_OBJECT_PREFIX = "open_data/parliamentary_questions/answered_questions_"


### PR DESCRIPTION
Older versions of `requests` had security vulnerability [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)

This should be retro-compatible have any impact on the DAG logic.

See Release: https://github.com/moj-analytical-services/pq_scraper/releases/tag/v0.1.3