### PR TITLE
updates occupeye scraper image

### DIFF
--- a/occupeye_scraper_daily.py
+++ b/occupeye_scraper_daily.py
@@ -23,7 +23,7 @@ try:
 
     surveys_to_s3 = KubernetesPodOperator(
         namespace="airflow",
-        image="593291632749.dkr.ecr.eu-west-1.amazonaws.com/airflow-occupeye-scraper:v0.5",
+        image="593291632749.dkr.ecr.eu-west-1.amazonaws.com/airflow-occupeye-scraper:v0.6",
         env_vars={
             "AWS_METADATA_SERVICE_TIMEOUT": "60",
             "AWS_METADATA_SERVICE_NUM_ATTEMPTS": "5"


### PR DESCRIPTION
This updates the scraper to also output to a shadow database in the app bucket, to allow the app to poll it via dbtools rather than relying on a pre-scraped cache. This should render the `occupeye_aggregator` DAG obsolete, once the app has been rewritten to accept this new architecture.

The changes to the image are all contained in this PR:
https://github.com/moj-analytical-services/airflow-occupeye-scraper/pull/18