### PR TITLE
KPI - switch off catchup/backfill 

### DIFF
--- a/platform_kpis.py
+++ b/platform_kpis.py
@@ -12,7 +12,6 @@ try:
     from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
     args = {"owner": "David",
-            "start_date": days_ago(0),
             "retries": 3,
             "retry_delay": timedelta(minutes=5),
             "email_on_failure": True,
@@ -22,7 +21,8 @@ try:
     dag = DAG(
         dag_id="platform_kpi_scraper",
         default_args=args,
-        schedule_interval='0 * * * *',
+        schedule_interval='@hourly',
+        catchup=False,
     )
     # https://github.com/apache/incubator-airflow/blob/5a3f39913739998ca2e9a17d0f1d10fccb840d36/airflow/contrib/operators/kubernetes_pod_operator.py#L129
     surveys_to_s3 = KubernetesPodOperator(

--- a/platform_kpis.py
+++ b/platform_kpis.py
@@ -12,6 +12,7 @@ try:
     from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
     args = {"owner": "David",
+            "start_date": days_ago(0),
             "retries": 3,
             "retry_delay": timedelta(minutes=5),
             "email_on_failure": True,


### PR DESCRIPTION
Because kpi scripts do the analysis for all time on every invocation